### PR TITLE
Fix ML-DSA docs: sign output field is `signature`, not `sigma`

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ Or if the function isn't supported:
 | Function | Inputs | Params | Outputs |
 |---|---|---|---|
 | `ML_DSA_KeyGen` | `seed` (32 bytes) | `param_set` (44/65/87) | `pk`, `sk` |
-| `ML_DSA_Sign` | `sk`, `message`, `rnd` (32 bytes) | — | `sigma` |
-| `ML_DSA_Verify` | `pk`, `message`, `sigma` | — | `valid` ("01" or "00") |
+| `ML_DSA_Sign` | `sk`, `message`, `rnd` (32 bytes) | — | `signature` |
+| `ML_DSA_Verify` | `pk`, `message`, `signature` | — | `valid` ("01" or "00") |
 
 ## Writing a New Harness
 

--- a/harnesses/circl/main.go
+++ b/harnesses/circl/main.go
@@ -349,7 +349,7 @@ func handleDSASign(req *Request) Response {
 		sig := make([]byte, mldsa44.SignatureSize)
 		circlSignTo44(&sk, message, rndArr, sig)
 		return okResp(map[string]string{
-			"sigma": hex.EncodeToString(sig),
+			"signature": hex.EncodeToString(sig),
 		})
 	case 65:
 		var sk mldsa65.PrivateKey
@@ -359,7 +359,7 @@ func handleDSASign(req *Request) Response {
 		sig := make([]byte, mldsa65.SignatureSize)
 		circlSignTo65(&sk, message, rndArr, sig)
 		return okResp(map[string]string{
-			"sigma": hex.EncodeToString(sig),
+			"signature": hex.EncodeToString(sig),
 		})
 	case 87:
 		var sk mldsa87.PrivateKey
@@ -369,7 +369,7 @@ func handleDSASign(req *Request) Response {
 		sig := make([]byte, mldsa87.SignatureSize)
 		circlSignTo87(&sk, message, rndArr, sig)
 		return okResp(map[string]string{
-			"sigma": hex.EncodeToString(sig),
+			"signature": hex.EncodeToString(sig),
 		})
 	default:
 		return errResp(fmt.Sprintf("unsupported param_set: %d", paramSet))


### PR DESCRIPTION
The battery reads `signature` everywhere.

The README and circl harness were the only places using the `sigma` name.